### PR TITLE
fix: resolve faction display issues in Who You Own page

### DIFF
--- a/src/fsd/4-entities/faction/faction.icon.tsx
+++ b/src/fsd/4-entities/faction/faction.icon.tsx
@@ -2,8 +2,11 @@
 
 import { getImageUrl } from '@/fsd/5-shared/ui';
 
-export const FactionImage = ({ faction }: { faction: string }) => {
-    const imageUrl = getImageUrl(`factions/${faction}.png`);
+export const FactionImage = ({ faction, icon }: { faction: string; icon?: string }) => {
+    // Use the provided icon filename or fallback to faction name
+    const iconFilename = icon || `${faction}.png`;
+
+    const imageUrl = getImageUrl(`factions/${iconFilename}`);
 
     return (
         <img

--- a/src/v2/data/factions.json
+++ b/src/v2/data/factions.json
@@ -7,8 +7,8 @@
     },
     {
         "alliance": "Imperial",
-        "name": "Adepta Sororitas",
-        "icon": "ADEPTA_SORORITAS.png",
+        "name": "Sisterhood",
+        "icon": "Adepta Sororitas.png",
         "color": "#962C38"
     },
     {
@@ -19,20 +19,20 @@
     },
     {
         "alliance": "Imperial",
-        "name": "Astra Militarum",
-        "icon": "Astra_militarum.png",
+        "name": "AstraMilitarum",
+        "icon": "Astra Militarum.png",
         "color": "#717838"
     },
     {
         "alliance": "Chaos",
-        "name": "Black Legion",
-        "icon": "Black_Legion.png",
+        "name": "BlackLegion",
+        "icon": "Black Legion.png",
         "color": "#1C0F10"
     },
     {
         "alliance": "Chaos",
-        "name": "Death guard",
-        "icon": "Death_Guard.png",
+        "name": "DeathGuard",
+        "icon": "Death guard.png",
         "color": "#65540C"
     },
     {
@@ -43,8 +43,8 @@
     },
     {
         "alliance": "Imperial",
-        "name": "Black Templars",
-        "icon": "Black_Templars.png",
+        "name": "BlackTemplars",
+        "icon": "Black Templars.png",
         "color": "#929395"
     },
     {
@@ -55,26 +55,26 @@
     },
     {
         "alliance": "Xenos",
-        "name": "T'au Empire",
-        "icon": "T_Au.png",
+        "name": "Tau",
+        "icon": "T'au Empire.png",
         "color": "#CE7140"
     },
     {
         "alliance": "Imperial",
-        "name": "Space Wolves",
-        "icon": "Space_Wolves.png",
+        "name": "SpaceWolves",
+        "icon": "Space Wolves.png",
         "color": "#084A92"
     },
     {
         "alliance": "Chaos",
-        "name": "Thousand Sons",
-        "icon": "Thousand_Sons.png",
+        "name": "ThousandSons",
+        "icon": "Thousand Sons.png",
         "color": "#084A92"
     },
     {
         "alliance": "Imperial",
-        "name": "Dark Angels",
-        "icon": "Dark_Angels.png",
+        "name": "DarkAngels",
+        "icon": "Dark Angels.png",
         "color": "#18542B"
     },
     {
@@ -85,37 +85,37 @@
     },
     {
         "alliance": "Imperial",
-        "name": "Adeptus Mechanicus",
-        "icon": "AdeptusMechanicus.png",
+        "name": "AdeptusMechanicus",
+        "icon": "Adeptus Mechanicus.png",
         "color": "#781e2e"
     },
     {
         "alliance": "Chaos",
-        "name": "World Eaters",
-        "icon": "worldeaters.png",
+        "name": "WorldEaters",
+        "icon": "World Eaters.png",
         "color": "#511011"
     },
     {
         "alliance": "Imperial",
-        "name": "Blood Angels",
-        "icon": "blood_angels.png",
+        "name": "BloodAngels",
+        "icon": "Blood Angels.png",
         "color": "#ac1b1a"
     },
     {
         "alliance": "Xenos",
-        "name": "Genestealer Cults",
+        "name": "Genestealers",
         "icon": "Genestealer Cults.png",
         "color": "#CE7140"
     },
     {
         "alliance": "Imperial",
-        "name": "Adeptus Custodes",
+        "name": "Custodes",
         "icon": "Adeptus Custodes.png",
         "color": "#652129"
     },
     {
         "alliance": "Chaos",
-        "name": "Emperor's Children",
+        "name": "EmperorsChildren",
         "icon": "Emperor's Children.png",
         "color": "#874470"
     }

--- a/src/v2/features/characters/components/faction-tile.tsx
+++ b/src/v2/features/characters/components/faction-tile.tsx
@@ -48,7 +48,7 @@ export const FactionsTile = ({
         <div className="faction">
             <h4 className="faction-title" style={{ backgroundColor: faction.color }}>
                 <div className="faction-icon">
-                    <FactionImage faction={faction.name} />
+                    <FactionImage faction={faction.name} icon={faction.icon} />
                     <span>{faction.name.toUpperCase()}</span>
                 </div>
                 <Conditional condition={showBsValue}>


### PR DESCRIPTION
- Update faction names in factions.json to match character data
  * Sisterhood, AstraMilitarum, BlackLegion, DeathGuard, etc.
- Fix faction icon filenames to match actual files in assets
  * Handle spaces in filenames like 'Adepta Sororitas.png'
- Update FactionImage component to accept icon prop from faction data
  * Avoids ESLint no-internal-modules issues
- Remove unused characterId props from character title components

Fixes: Missing characters in factions like Adeptus Sororitas, Astra Militarum, Death Guard, and Black Legion

NOTE: I dont know where the factions.json came from, but i changed it to match what is in the newCharacters.json which I assume came from the data miner. 