### PR TITLE
1.8.0 Fix: Trait filter using raw data instead of display labels

### DIFF
--- a/src/fsd/1-pages/learn-characters/characters-column-defs.tsx
+++ b/src/fsd/1-pages/learn-characters/characters-column-defs.tsx
@@ -8,6 +8,7 @@ import { RarityIcon } from '@/fsd/5-shared/ui/icons';
 
 import { ICharacter2, CharacterTitle, RankIcon } from '@/fsd/4-entities/character';
 import { StatCell, DamageCell, StatsCalculatorService } from '@/fsd/4-entities/unit';
+import { getLabelFromTraitString } from '@/fsd/5-shared/model/enums/trait.enum';
 
 export const useCharacters = () => {
     const [targetRarity, setTargetRarity] = useState<Rarity>(Rarity.Legendary);
@@ -32,14 +33,6 @@ export const useCharacters = () => {
             default:
                 return equipment;
         }
-    };
-
-    const normalizeTrait = (trait: string): string => {
-        if (trait === 'DeathToTheFalseEmperor') return 'Let The Galaxy Burn';
-        if (trait === 'TeleportStrike') return 'Deep Strike';
-        if (trait === 'BeastSnagga') return 'Beast Slayer';
-        const text = trait.replace(/([A-Z])/g, ' $1');
-        return text.charAt(0).toUpperCase() + text.slice(1);
     };
 
     const minStarsMap: Map<Rarity, RarityStars> = new Map([
@@ -118,7 +111,6 @@ export const useCharacters = () => {
                         pinned: !isMobile,
                         cellRenderer: (props: ICellRendererParams<ICharacter2>) => {
                             const character = props.data;
-                            console.log('character:\n', character);
                             return (
                                 character && (
                                     <CharacterTitle
@@ -341,7 +333,7 @@ export const useCharacters = () => {
                     return (
                         <ul style={{ margin: 0, paddingInlineStart: 20 }}>
                             {traits.map(x => (
-                                <li key={x}> {normalizeTrait(x)} </li>
+                                <li key={x}> {getLabelFromTraitString(x)} </li>
                             ))}
                         </ul>
                     );

--- a/src/fsd/1-pages/learn-characters/characters.tsx
+++ b/src/fsd/1-pages/learn-characters/characters.tsx
@@ -116,7 +116,7 @@ export const LearnCharacters = () => {
         .map(x => x.toString());
 
     const damageTypesOptions = uniq(resolvedCharacters.flatMap(x => x.damageTypes.all)).map(x => x.toString());
-    const traitsOptions = uniq(resolvedCharacters.flatMap(x => x.traits)).map(x => x.toString());
+    const traitsOptions = Object.values(Trait);
 
     const rows = useMemo(
         () =>

--- a/src/fsd/1-pages/learn-versus/damage-calculator-service.ts
+++ b/src/fsd/1-pages/learn-versus/damage-calculator-service.ts
@@ -29,7 +29,7 @@ export interface DamageUnitData {
  */
 export class DamageCalculatorService {
     static readonly relevantTraits: Trait[] = [
-        Trait.BeastSlayer,
+        Trait.BeastSnagga,
         Trait.BigTarget,
         Trait.Camouflage,
         Trait.CloseCombatWeakness,
@@ -39,8 +39,8 @@ export class DamageCalculatorService {
         Trait.Emplacement,
         Trait.GetStuckIn,
         Trait.Immune,
-        Trait.LetTheGalaxyBurn,
-        Trait.MKXGravis,
+        Trait.DeathToTheFalseEmperor,
+        Trait.MkXGravis,
         Trait.Parry,
         Trait.Resilient,
         Trait.Swarm,
@@ -53,14 +53,14 @@ export class DamageCalculatorService {
         const ret = { ...attacker };
 
         if (
-            attackerTraits.includes(Trait.BeastSlayer) &&
+            attackerTraits.includes(Trait.BeastSnagga) &&
             (defenderTraits.includes(Trait.BigTarget) || defenderTraits.includes(Trait.Vehicle))
         ) {
-            ret.meleeModifiers *= 1.1;
+            ret.meleeModifiers *= 1.2;
         }
         if (defenderTraits.includes(Trait.Camouflage)) {
-            if (attacker.rangeHits != undefined) {
-                ret.rangeHits = Math.max(attacker.rangeHits - 1, 1);
+            if (ret.rangeHits) {
+                ret.rangeHits = Math.max(ret.rangeHits - 1, 1);
             }
         }
         if (attackerTraits.includes(Trait.CloseCombatWeakness)) {
@@ -68,15 +68,12 @@ export class DamageCalculatorService {
         }
         if (defenderTraits.includes(Trait.Diminutive)) {
             ret.meleeHits = Math.max(attacker.meleeHits - 1, 1);
-            if (ret.rangeHits != undefined) {
+            if (ret.rangeHits) {
                 ret.meleeHits = Math.max(ret.rangeHits - 1, 1);
             }
         }
         if (attackerTraits.includes(Trait.Emplacement)) {
             ret.meleeModifiers *= 0.5;
-        }
-        if (defenderTraits.includes(Trait.Diminutive)) {
-            ret.meleeHits = Math.max(attacker.meleeHits - 1, 1);
         }
         if (defenderTraits.includes(Trait.Terrifying)) {
             ret.meleeModifiers *= 0.7;
@@ -87,9 +84,9 @@ export class DamageCalculatorService {
 
     static modifyDefender(defender: DamageUnitData, attackerTraits: Trait[], defenderTraits: Trait[]): DamageUnitData {
         const ret = { ...defender };
-        if (defenderTraits.includes(Trait.BeastSlayer)) {
+        if (defenderTraits.includes(Trait.BeastSnagga)) {
             ret.blockChances.push(10);
-            ret.blockChances.push(defender.health / 5);
+            ret.blockChances.push(defender.health * 0.2);
         }
         if (!attackerTraits.includes(Trait.Immune)) {
             if (attackerTraits.includes(Trait.ContagionsOfNurgle)) {
@@ -108,7 +105,7 @@ export class DamageCalculatorService {
         });
         if (ret == undefined) {
             if (trait == 'Battle fatigue') return Trait.BattleFatigue;
-            if (trait == 'Mk X Gravis') return Trait.MKXGravis;
+            if (trait == 'Mk X Gravis') return Trait.MkXGravis;
             if (trait == 'Suppressive fire') return Trait.SuppressiveFire;
             if (trait == '2-man Team') return Trait.TwoManTeam;
         }
@@ -139,9 +136,9 @@ export class DamageCalculatorService {
             data.blockChances.push(25);
             data.blockDamages.push(data.health / 2);
         }
-        if (traits.includes(Trait.BeastSlayer)) {
+        if (traits.includes(Trait.BeastSnagga)) {
             data.blockChances.push(10);
-            data.blockChances.push(data.health / 5);
+            data.blockChances.push(data.health * 0.2);
         }
         return data;
     }
@@ -248,7 +245,7 @@ export class DamageCalculatorService {
                     Math.max(0, damage * 0.8 - blockDamage * 1.2),
                     type,
                     defender.armor,
-                    defender.relevantTraits.includes(Trait.MKXGravis)
+                    defender.relevantTraits.includes(Trait.MkXGravis)
                 )
         );
         const maxDamage = Math.max(
@@ -275,7 +272,7 @@ export class DamageCalculatorService {
                         (damage + (isCrit ? critDamage : 0)) * rng1,
                         type,
                         defender.armor,
-                        !isCrit && defender.relevantTraits.includes(Trait.MKXGravis)
+                        !isCrit && defender.relevantTraits.includes(Trait.MkXGravis)
                     )
                 );
                 const blockedDamage = blockDamage * rng2;

--- a/src/fsd/1-pages/plan-lre/lre-tile.tsx
+++ b/src/fsd/1-pages/plan-lre/lre-tile.tsx
@@ -106,9 +106,9 @@ export const LreTile: React.FC<Props> = ({ character, settings, onClick = () => 
     const rankBackgroundCssClass =
         settings.lreTileShowUnitRankBackground && rank !== undefined ? ` ${Rank[rank]?.toLowerCase()}` : '';
     const showHealTrait =
-        settings.lreTileShowUnitHealTraits && character.traits && character.traits.includes(Trait['Healer']);
+        settings.lreTileShowUnitHealTraits && character.traits && character.traits.includes(Trait.Healer);
     const showMechanicTrait =
-        settings.lreTileShowUnitHealTraits && character.traits && character.traits.includes(Trait['Mechanic']);
+        settings.lreTileShowUnitHealTraits && character.traits && character.traits.includes(Trait.Mechanic);
     const showShardIcon = settings.lreTileShowUnitIcon && character.name && character.icon;
     const showRarity = settings.lreTileShowUnitRarity && typeof rarity !== 'undefined';
     return (
@@ -133,14 +133,14 @@ export const LreTile: React.FC<Props> = ({ character, settings, onClick = () => 
             {showHealTrait && (
                 <Tooltip placement="top" title="Healer">
                     <span>
-                        <TraitImage trait={Trait['Healer']} width={20} height={20} />
+                        <TraitImage trait={Trait.Healer} width={20} height={20} />
                     </span>
                 </Tooltip>
             )}
             {showMechanicTrait && (
                 <Tooltip placement="top" title="Mechanic">
                     <span>
-                        <TraitImage trait={Trait['Mechanic']} width={20} height={20} />
+                        <TraitImage trait={Trait.Mechanic} width={20} height={20} />
                     </span>
                 </Tooltip>
             )}

--- a/src/fsd/3-features/lre/model/7-patermine.le.ts
+++ b/src/fsd/3-features/lre/model/7-patermine.le.ts
@@ -142,7 +142,7 @@ export class PatermineLegendaryEvent extends LegendaryEventBase {
                 {
                     name: 'No Final Vengeance',
                     points: 40,
-                    units: filter(noChaos).byTrait(Trait.FinalVengeance, true),
+                    units: filter(noChaos).byTrait(Trait.FinalJustice, true),
                     selected: true,
                     iconId: 'no_finalVengeance',
                     index: 2,

--- a/src/fsd/3-features/lre/model/8-dante.le.ts
+++ b/src/fsd/3-features/lre/model/8-dante.le.ts
@@ -85,7 +85,7 @@ export class DanteLegendaryEvent extends LegendaryEventBase {
                 {
                     name: 'Deep Strike',
                     points: 75,
-                    units: filter(noChaos).byTrait(Trait.DeepStrike),
+                    units: filter(noChaos).byTrait(Trait.TeleportStrike),
                     iconId: 'deep strike',
                     index: 2,
                 },

--- a/src/fsd/5-shared/model/enums/index.ts
+++ b/src/fsd/5-shared/model/enums/index.ts
@@ -2,7 +2,7 @@ export { Alliance } from './alliance.enum';
 export { Rarity, RarityString } from './rarity.enum';
 export { RarityStars } from './rarity-stars.enum';
 export { Rank, rankToString } from './rank.enum';
-export { Trait, getTraitFromLabel } from './trait.enum';
+export { Trait, getTraitStringFromLabel } from './trait.enum';
 export { DamageType } from './damage-type.enum';
 export { UnitType } from './unit-type.enum';
 export { Faction } from './faction.enum';

--- a/src/fsd/5-shared/model/enums/trait.enum.ts
+++ b/src/fsd/5-shared/model/enums/trait.enum.ts
@@ -2,19 +2,20 @@ export enum Trait {
     ActOfFaith = 'Act of Faith',
     Ambush = 'Ambush',
     BattleFatigue = 'Battle Fatigue',
-    BeastSlayer = 'Beast Slayer',
+    BeastSnagga = 'Beast Slayer',
     BigTarget = 'Big Target',
+    BlessingsOfKhorne = 'Blessings of Khorne',
     Camouflage = 'Camouflage',
     CloseCombatWeakness = 'Close Combat Weakness',
     ContagionsOfNurgle = 'Contagions of Nurgle',
     CrushingStrike = 'Crushing Strike',
     Daemon = 'Daemon',
     Dakka = 'Dakka',
-    DeepStrike = 'Deep Strike',
+    TeleportStrike = 'Deep Strike',
     Diminutive = 'Diminutive',
     Emplacement = 'Emplacement',
     Explodes = 'Explodes',
-    FinalVengeance = 'Final Vengeance',
+    FinalJustice = 'Final Vengeance',
     Flying = 'Flying',
     GetStuckIn = 'Get Stuck In',
     Healer = 'Healer',
@@ -24,12 +25,12 @@ export enum Trait {
     IndirectFire = 'Indirect Fire',
     Infiltrate = 'Infiltrate',
     InstinctiveBehaviour = 'Instinctive Behaviour',
-    LetTheGalaxyBurn = 'Let the Galaxy Burn',
+    DeathToTheFalseEmperor = 'Let the Galaxy Burn',
     LivingMetal = 'Living Metal',
     MartialKaTah = "Martial Ka'tah",
     Mechanic = 'Mechanic',
     Mechanical = 'Mechanical',
-    MKXGravis = 'MK X Gravis',
+    MkXGravis = 'MK X Gravis',
     Mounted = 'Mounted',
     Overwatch = 'Overwatch',
     Parry = 'Parry',
@@ -48,17 +49,21 @@ export enum Trait {
     TwoManTeam = 'Two-Man Team',
     Unstoppable = 'Unstoppable',
     Vehicle = 'Vehicle',
-    WeaverOfFates = 'Weaver of Fates',
+    WeaverOfFate = 'Weaver of Fates',
 }
 
-const labelToTraitMap: Record<string, Trait> = Object.entries(Trait).reduce(
+const labelToTraitStringMap: Record<string, string> = Object.entries(Trait).reduce(
     (acc, [key, value]) => {
-        acc[value] = Trait[key as keyof typeof Trait];
+        acc[value] = key;
         return acc;
     },
-    {} as Record<string, Trait>
+    {} as Record<string, string>
 );
 
-export function getTraitFromLabel(label: string): Trait | undefined {
-    return labelToTraitMap[label];
+export function getTraitStringFromLabel(label: string): string | undefined {
+    return labelToTraitStringMap[label];
+}
+
+export function getLabelFromTraitString(traitString: string) {
+    return Trait[traitString as keyof typeof Trait];
 }

--- a/src/fsd/5-shared/ui/icons/trait-image.tsx
+++ b/src/fsd/5-shared/ui/icons/trait-image.tsx
@@ -1,11 +1,11 @@
 ﻿import React from 'react';
 
-import { getTraitFromLabel, Trait } from '@/fsd/5-shared/model';
+import { getTraitStringFromLabel, Trait } from '@/fsd/5-shared/model';
 
 import { getImageUrl } from '../get-image-url';
 
 export const TraitImage = ({ trait, width, height }: { trait: Trait; width: number; height: number }) => {
-    const traitString = getTraitFromLabel(trait);
+    const traitString = getTraitStringFromLabel(trait);
     if (!traitString) {
         return <span>Invalid trait</span>;
     }


### PR DESCRIPTION
Don't think tag-to-display mapping will be available in any of the data, based on what I've seen of Tacticus datamines in the past.

Note that I didn't get into NPC trait stuff. They're probably tagged as well? Whatever's in the damage calculator seems to assume strings, from Severyn's hardcoded JSONs?