### PR TITLE
Fix MOW faction filtering by updating faction names to match snowprin…

### DIFF
--- a/src/fsd/4-entities/mow/data/mows.json
+++ b/src/fsd/4-entities/mow/data/mows.json
@@ -7,7 +7,7 @@
         "shortName": "Malleus RL",
         "fullName": "Malleus Rocket Launcher",
         "alliance": "Imperial",
-        "faction": "Astra Militarum",
+        "faction": "AstraMilitarum",
         "initialRarity": "Common",
         "deployableAlliance": "Xenos"
     },
@@ -19,7 +19,7 @@
         "shortName": "Forgefiend",
         "fullName": "Forgefiend",
         "alliance": "Chaos",
-        "faction": "Black Legion",
+        "faction": "BlackLegion",
         "initialRarity": "Common",
         "deployableAlliance": "Imperial"
     },
@@ -56,7 +56,7 @@
         "shortName": "Tson",
         "fullName": "Shas'vre Vior'la Tson'ji",
         "alliance": "Xenos",
-        "faction": "T'au Empire",
+        "faction": "Tau",
         "initialRarity": "Common",
         "deployableAlliance": "Imperial",
         "releaseDate": "2024-12-02T00:00:00Z"
@@ -69,7 +69,7 @@
         "shortName": "Plagueburst",
         "fullName": "Plagueburst Crawler",
         "alliance": "Chaos",
-        "faction": "Death guard",
+        "faction": "DeathGuard",
         "initialRarity": "Common",
         "deployableAlliance": "Xenos",
         "releaseDate": "2025-03-17T00:00:00Z"
@@ -82,7 +82,7 @@
         "shortName": "Exorcist",
         "fullName": "Exorcist",
         "alliance": "Imperial",
-        "faction": "Adepta Sororitas",
+        "faction": "Sisterhood",
         "initialRarity": "Common",
         "deployableAlliance": "Xenos",
         "releaseDate": "2025-06-30T00:00:00Z"


### PR DESCRIPTION
Updated the faction names in src/fsd/4-entities/mow/data/mows.json to match the snowprintId values from factions.json:
Malleus RL: "Astra Militarum" → "AstraMilitarum"
Forgefiend: "Black Legion" → "BlackLegion"
Tson'Ji: "T'au Empire" → "Tau"
Plagueburst Crawler: "Death guard" → "DeathGuard"
Exorcist: "Adepta Sororitas" → "Sisterhood"
What This Fixes
Now when the "who you own" page groups MOWs by faction and looks them up using the snowprintId from the factions data, there will be a proper match. This means:
All MOWs will now appear in faction filters when you select Imperial, Chaos, or Xenos
MOWs will be properly grouped in the faction view (when ordering by faction)
The faction filtering will work consistently across all MOWs, not just Necrons and Ultramarines
The fix ensures that the faction names used in MOW data exactly match the snowprintId values used in the factions data, which is what the orderByFaction function expects when grouping units by faction.
