### PR TITLE
Fix lint error

### DIFF
--- a/src/fsd/1-pages/learn-characters/characters-column-defs.tsx
+++ b/src/fsd/1-pages/learn-characters/characters-column-defs.tsx
@@ -3,12 +3,19 @@ import React, { useMemo, useState } from 'react';
 import { isMobile } from 'react-device-detect';
 
 import { getEnumValues } from '@/fsd/5-shared/lib';
-import { RarityStars, Rarity, DamageType, Rank, Trait, RarityMapper } from '@/fsd/5-shared/model';
+import {
+    RarityStars,
+    Rarity,
+    DamageType,
+    Rank,
+    Trait,
+    RarityMapper,
+    getLabelFromTraitString,
+} from '@/fsd/5-shared/model';
 import { RarityIcon } from '@/fsd/5-shared/ui/icons';
 
 import { ICharacter2, CharacterTitle, RankIcon } from '@/fsd/4-entities/character';
 import { StatCell, DamageCell, StatsCalculatorService } from '@/fsd/4-entities/unit';
-import { getLabelFromTraitString } from '@/fsd/5-shared/model/enums/trait.enum';
 
 export const useCharacters = () => {
     const [targetRarity, setTargetRarity] = useState<Rarity>(Rarity.Legendary);

--- a/src/fsd/5-shared/model/enums/index.ts
+++ b/src/fsd/5-shared/model/enums/index.ts
@@ -2,7 +2,7 @@ export { Alliance } from './alliance.enum';
 export { Rarity, RarityString } from './rarity.enum';
 export { RarityStars } from './rarity-stars.enum';
 export { Rank, rankToString } from './rank.enum';
-export { Trait, getTraitStringFromLabel } from './trait.enum';
+export { Trait, getTraitStringFromLabel, getLabelFromTraitString } from './trait.enum';
 export { DamageType } from './damage-type.enum';
 export { UnitType } from './unit-type.enum';
 export { Faction } from './faction.enum';


### PR DESCRIPTION
FSD rules forbid reaching deeply into other modules, so we now export the getLabelFromTraitString function and import it from the module index.

You can run `npm run build-ci` to run all checks, including ESLint, to see what will fail in CI.