### PR TITLE
Fix for unit name and unit portrait on charater details

### DIFF
--- a/src/fsd/4-entities/character/ui/character-title.tsx
+++ b/src/fsd/4-entities/character/ui/character-title.tsx
@@ -25,7 +25,7 @@ export const CharacterTitle = ({
     fullName?: boolean;
     imageSize?: number;
 }) => {
-    const name = fullName ? character.fullName : character.name;
+    const name = fullName ? character.fullName : character.id;
 
     const isUnlocked = character.rank > Rank.Locked;
 
@@ -40,7 +40,7 @@ export const CharacterTitle = ({
 
     return (
         <div style={{ display: 'flex', gap: 10, alignItems: 'center', opacity, cursor }} onClick={onClick}>
-            <UnitShardIcon key={character.name} icon={character.icon} name={character.name} height={imageSize} />
+            <UnitShardIcon key={character.name} icon={character.roundIcon} name={character.id} height={imageSize} />
             {!hideName && <span>{name}</span>}
             <RarityIcon rarity={character.rarity} />
             {isUnlocked ? <RankIcon key={character.rank} rank={character.rank} /> : undefined}


### PR DESCRIPTION
fixes to show the unit name and the round icon on the character details tile