### PR TITLE
Fix Goals UI bugs

### DIFF
--- a/src/routes/goals/goals.tsx
+++ b/src/routes/goals/goals.tsx
@@ -102,7 +102,7 @@ export const Goals = () => {
 
         if (item === 'edit') {
             const goal = allGoals.find(x => x.goalId === goalId);
-            const relatedUnit = [...characters, ...resolvedMows].find(x => x.snowprintId === goal?.unitId);
+            const relatedUnit = [...characters, ...resolvedMows].find(x => x.id === goal?.unitId);
             if (relatedUnit && goal) {
                 setEditUnit(relatedUnit);
                 setEditGoal(goal);

--- a/src/shared-components/goals/edit-goal-dialog.tsx
+++ b/src/shared-components/goals/edit-goal-dialog.tsx
@@ -121,7 +121,7 @@ export const EditGoalDialog: React.FC<Props> = ({ isOpen, onClose, goal, unit })
                 });
             }
 
-            enqueueSnackbar(`Goal for ${updatedGoal.unitName} is updated`, { variant: 'success' });
+            enqueueSnackbar(`Goal for ${updatedGoal.unitId} is updated`, { variant: 'success' });
         }
         setOpenDialog(false);
         if (onClose) {

--- a/src/shared-components/goals/set-goal-dialog.tsx
+++ b/src/shared-components/goals/set-goal-dialog.tsx
@@ -84,7 +84,8 @@ export const SetGoalDialog = ({ onClose }: { onClose?: (goal?: IPersonalGoal) =>
         if (goal) {
             goal.dailyRaids = [PersonalGoalType.UpgradeRank, PersonalGoalType.MowAbilities].includes(goal.type);
             dispatch.goals({ type: 'Add', goal });
-            enqueueSnackbar(`Goal for ${goal.character} is added`, { variant: 'success' });
+            const character = characters.find(c => c.snowprintId === goal.character);
+            enqueueSnackbar(`Goal for ${character?.shortName ?? goal.character} is added`, { variant: 'success' });
         }
         setOpenDialog(false);
         setUnit(null);


### PR DESCRIPTION
This PR fixes a few UI bugs in the Goals page:

- trying to edit an existing goal by clicking the pencil icon was doing nothing
- after setting/editing a goal, the snowprintID was being displayed in the notification bar